### PR TITLE
Do not use Promise.all() to resolve promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Do not use `Promise.all` to resolve multiple promises. `Promise.all` fails
+  fast, rejecting instantly once any of the promises rejects. This causes
+  unhandled promise rejections when more than one promise fails in array.
+
 ## 0.3.0 - 2020-10-29
 
 - Upgrade SDK v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 0.3.1 - 2020-11-19
+
 ### Changed
 
 - Do not use `Promise.all` to resolve multiple promises. `Promise.all` fails

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-bamboohr",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Graph Conversion Project for BambooHR",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/access.ts
+++ b/src/steps/access.ts
@@ -54,16 +54,14 @@ export async function fetchUsers({
       },
     });
 
-    await Promise.all([
-      jobState.addEntity(userEntity),
-      jobState.addRelationship(
-        createDirectRelationship({
-          _class: RelationshipClass.HAS,
-          from: accountEntity,
-          to: userEntity,
-        }),
-      ),
-    ]);
+    await jobState.addEntity(userEntity);
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.HAS,
+        from: accountEntity,
+        to: userEntity,
+      }),
+    );
   });
 }
 

--- a/src/steps/account.ts
+++ b/src/steps/account.ts
@@ -32,10 +32,8 @@ export async function fetchAccountDetails({
     },
   });
 
-  await Promise.all([
-    jobState.addEntity(accountEntity),
-    jobState.setData(ACCOUNT_ENTITY_DATA_KEY, accountEntity),
-  ]);
+  await jobState.addEntity(accountEntity);
+  await jobState.setData(ACCOUNT_ENTITY_DATA_KEY, accountEntity);
 }
 
 export const accountSteps: IntegrationStep<IntegrationConfig>[] = [

--- a/src/steps/company-files.ts
+++ b/src/steps/company-files.ts
@@ -41,16 +41,14 @@ export async function fetchCompanyFiles({
       },
     });
 
-    await Promise.all([
-      jobState.addEntity(fileEntity),
-      jobState.addRelationship(
-        createDirectRelationship({
-          _class: RelationshipClass.HAS,
-          from: accountEntity,
-          to: fileEntity,
-        }),
-      ),
-    ]);
+    await jobState.addEntity(fileEntity);
+    await jobState.addRelationship(
+      createDirectRelationship({
+        _class: RelationshipClass.HAS,
+        from: accountEntity,
+        to: fileEntity,
+      }),
+    );
   });
 }
 

--- a/src/steps/employee-files.ts
+++ b/src/steps/employee-files.ts
@@ -41,16 +41,14 @@ export async function fetchEmployeeFiles({
             },
           });
 
-          await Promise.all([
-            jobState.addEntity(fileEntity),
-            jobState.addRelationship(
-              createDirectRelationship({
-                _class: RelationshipClass.HAS,
-                from: userEntity,
-                to: fileEntity,
-              }),
-            ),
-          ]);
+          await jobState.addEntity(fileEntity);
+          await jobState.addRelationship(
+            createDirectRelationship({
+              _class: RelationshipClass.HAS,
+              from: userEntity,
+              to: fileEntity,
+            }),
+          );
         },
       );
     },


### PR DESCRIPTION
After investigating some errors that did not make it into our production error handling system, we noticed a few unhandled promise rejections that were thrown in this integration. It looks like this was related to two promises wrapped in `Promise.all()` that both failed.

This change should fix the issues we're seeing in this integration, but we'll need to come to a longer-term resolution in our managed SDK.