### PR TITLE
Fix authentication check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Added some grace to namespace configuration to allow for
   `jupiterone.bamboohr.com` and `https://jupiterone.bamboohr.com` as well as
   `jupiterone`
+- Fix authentication validation check that failed when there is no employee `0`
 
 ## 0.3.3 - 2020-11-30
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -66,7 +66,11 @@ export class APIClient {
         'GET',
       );
 
-      if (response.status !== 200) {
+      // A 200 is expected when authentication works and the employee exists A
+      // 404 is expected when authentication works and the employee does not
+      // exist There may be a better endpoint to verify authentication, but this
+      // one seems the most lightweight at this time.
+      if (response.status !== 200 && response.status !== 404) {
         throw new StatusError({
           message: 'Provider authentication failed',
           statusCode: response.status,


### PR DESCRIPTION
@a-u-h-g This "light weight auth check" was using an employee id that must not exist in every customers' account.