### PR TITLE
INT-2510 - Handle employee files 404 response

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -180,18 +180,26 @@ export class APIClient {
     employeeId: string,
     iteratee: ResourceIteratee<BambooHRFile>,
   ): Promise<void> {
-    const response = await this.request({
-      path: `v1/employees/${employeeId}/files/view`,
-    });
+    try {
+      const response = await this.request({
+        path: `v1/employees/${employeeId}/files/view`,
+      });
 
-    const files: BambooHRFilesResponse = await response.json();
-    const categoryFiles = files.categories.reduce(
-      (acc, category) => acc.concat(category.files),
-      [] as BambooHRFile[],
-    );
+      const files: BambooHRFilesResponse = await response.json();
+      const categoryFiles = files.categories.reduce(
+        (acc, category) => acc.concat(category.files),
+        [] as BambooHRFile[],
+      );
 
-    for (const file of categoryFiles) {
-      await iteratee(file);
+      for (const file of categoryFiles) {
+        await iteratee(file);
+      }
+    } catch (err) {
+      // if no files are found for the employee the endpoint will return 404.
+      // https://documentation.bamboohr.com/reference/list-employee-files-1
+      if (err.status !== 404) {
+        throw err;
+      }
     }
   }
 


### PR DESCRIPTION
@aiwilliams The 404 response seems to be if the employee doesn't have any files.

![image](https://user-images.githubusercontent.com/8009142/153448151-48225614-f831-4a5a-9584-abb79d866f4a.png)

This isn't obvious if one starts with a free trial with the demo data since they have introduced some folder structure for every employee so even if you remove all the files from a particular employee it still wouldn't result in 404 (I'm guessing because of all those folders structures make endpoint think that "data is there, it's just empty folders"). However, if you clear the demo data and make sure an employee has no data, it will result in an error which made it easy for testing/fixing it.

I think this was the problem/reason, but please correct me if you think I've overlooked something!